### PR TITLE
fix: Project 별 serializer Field 수정

### DIFF
--- a/pjt_back/projects/serializers.py
+++ b/pjt_back/projects/serializers.py
@@ -1,16 +1,15 @@
-from .models import Project, Participant, Applicant
+from .models import Project, Participant, Applicant, Status
 from accounts.models import User
-from objects.serializers import CampusSerializer, SkillCategorySerializer
+from objects.serializers import CampusSerializer, SkillCategorySerializer, SkillSerializer
 
 from rest_framework import serializers
 
 
 class UserSerializer(serializers.ModelSerializer):
-    campus = CampusSerializer()
 
     class Meta:
         model = User
-        fields = ('id', 'username', 'campus', 'part', 'skill', )
+        fields = ('id', 'username',)
 
 
 class ApplicantListSerializer(serializers.ModelSerializer):
@@ -26,10 +25,23 @@ class ParticipantSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Participant
+        fields = ('id', 'manager', 'skillcategory',)
+
+
+class StatusSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = Status
         fields = '__all__'
 
 
 class ProjectSerializer(serializers.ModelSerializer):
+    participant = ParticipantSerializer(many=True)
+    participant_count = serializers.IntegerField(source='participant.count', read_only=True)
+    campus = CampusSerializer()
+    founder = UserSerializer()
+    status = StatusSerializer()
+    skill = SkillSerializer(many=True)
 
     class Meta:
         model = Project

--- a/pjt_back/projects/views.py
+++ b/pjt_back/projects/views.py
@@ -46,7 +46,7 @@ def project_detail(request, project_id=None):
     if project_id:
         project = get_object_or_404(Project, id=project_id)
         if request.method == 'GET':
-            serializer = ProjectListSerializer(project)
+            serializer = ProjectSerializer(project)
         elif request.method == 'PUT':
             serializer = ProjectSerializer(project, data=request.data)
             if serializer.is_valid():


### PR DESCRIPTION
# 수정 사항
기존 Project 별 Serializer Field - `founder`, `participant` 경우
`skill` Field 가 포함되어 있었음
해당 필드를 아래와 같은 이유로 제거 및 API Guide 반영 완료 

- `founder` 경우 해당 유저 정보로 라우터 이동 되므로 skill 정보 불필요
- `participant` 경우 `founder` 와 동일 그리고 담당 `skillcategory` 만 알면 됨