### PR TITLE
Hot Fix

### DIFF
--- a/pjt_back/accounts/views.py
+++ b/pjt_back/accounts/views.py
@@ -40,12 +40,13 @@ def filtering_peoples(request):
 
     filter_count = 20
     count = int(count)
+    peoples_count = len(peoples)
     peoples = peoples[(count-1)*filter_count:count*filter_count]
-    return peoples
+    return peoples, peoples_count
 
 @api_view(['GET'])
 def peoples(request):
-    peoples = filtering_peoples(request)
+    peoples, peoples_count = filtering_peoples(request)
     peoples_json = []
     for people in peoples:
         position = people.position
@@ -74,7 +75,6 @@ def peoples(request):
         }
         peoples_json.append(people)
 
-    peoples_count = len(peoples)
     peoples = peoples_json
     context = {
         'peoples_count': peoples_count,


### PR DESCRIPTION
fix: 유저벌 필터링 count 수정
- 예를들어, skill 로 filtering 된 총 인원이 30 명 이라고 했을 때,
- count=1 : peoples_count = 20
- count=2 : peoples_count = 10
- 위와 같은 식으로 분류되어서 데이터를 반환했는데,
- 필터링 된 총 30명으로 반환